### PR TITLE
Fix .vim location

### DIFF
--- a/.vim
+++ b/.vim
@@ -1,1 +1,0 @@
-/Users/dave/src/dotfiles/vim

--- a/vimrc
+++ b/vimrc
@@ -1,7 +1,7 @@
 set nocompatible
 filetype off
 
-set rtp+=./.vim/bundle/vundle/
+set rtp+=~/.vim/bundle/vundle/
 call vundle#begin()
 
 " let Vundle manage Vundle - required!


### PR DESCRIPTION
The vim location has to be absolute. Therefore I changed it to your home directory:

```
~/.vim
```

You must have the .vim symlink in your home directory point to the /vim folder in the dotfiles.